### PR TITLE
Live preview 업데이트

### DIFF
--- a/css/extra.css
+++ b/css/extra.css
@@ -4,6 +4,8 @@ body { margin: 0; padding: 0; font-family: "Helvetica Neue", Helvetica, Arial, s
 
 pre { font-family: "Helvetica Neue", Helvetica, Arial, sans-serif; }
 
+hr { margin: 30px 0; border: none; height: 1px; background: #aaa; }
+
 main { margin: 15px; position: relative; }
 main > header > h1 { margin: 0; padding: 0 0 5px; font-size: 24px; }
 main > header > h1 a { color: #111; text-decoration: none; }

--- a/css/extra.scss
+++ b/css/extra.scss
@@ -11,6 +11,7 @@ body {
 	background: #fff;
 }
 pre {font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;}
+hr {margin: 30px 0; border: none; height: 1px; background: #aaa;}
 
 main {
 	margin: 15px; position: relative;

--- a/css/jsonEditor.css
+++ b/css/jsonEditor.css
@@ -3,8 +3,10 @@
 @media (-webkit-min-device-pixel-ratio: 2), (min-resolution: 192dpi) { .JSONEditor > div.index li > dl > dt > button, .JSONEditor > .context li[role=Type]:after, .JSONEditor > .context li[role=Insert]:after { background-image: url("../img/sp-icon@x2.png"); background-size: 100px 50px; } }
 
 /* json editor */
-.JSONEditor { /* index */ /* Context */ }
-.JSONEditor > div.index { border-width: 1px 0; border-style: solid; border-color: #ccc; font-size: 13px; }
+.JSONEditor { position: relative; /* index */ /* Context */ /* Preview */ }
+.JSONEditor *, .JSONEditor *:before, .JSONEditor *:after { box-sizing: border-box; -webkit-box-sizing: border-box; -moz-box-sizing: border-box; }
+.JSONEditor:after { content: ''; display: block; clear: both; }
+.JSONEditor > div.index { position: relative; padding: 8px 12px; margin: 0; border-width: 1px; border-style: solid; border-color: #ccc; font-size: 13px; }
 .JSONEditor > div.index ul { margin: 0; padding: 0 0 0 22px; list-style: none; clear: both; }
 .JSONEditor > div.index > ul { margin: 5px 0; padding-left: 0; }
 .JSONEditor > div.index li { padding: 0; margin: 2px 0; }
@@ -52,6 +54,7 @@
 .JSONEditor > div.index button[role=control] { background-position: -73px -24px; }
 .JSONEditor > div.index li.placeholder { position: relative; }
 .JSONEditor > div.index li.placeholder:before { position: absolute; content: ''; left: 0; right: 0; top: -1px; height: 3px; background: #7a7c7d; }
+.JSONEditor > div.index:before { content: 'Editor'; display: block; position: absolute; padding: 2px 6px 2px 8px; right: 0; top: 0; font-size: 12px; font-weight: 600; font-family: Verdana, sans-serif; color: #666; background: #f5f5f5; border-width: 0 0 1px 1px; border-style: solid; border-color: #ccc; border-bottom-left-radius: 3px; }
 .JSONEditor > .context { position: absolute; left: 0; top: 0; min-width: 120px; display: none; }
 .JSONEditor > .context ul { margin: 0; padding: 0; list-style: none; border: 1px solid #ccc; box-shadow: 0 2px 3px rgba(0, 0, 0, 0.1); background: #fff; }
 .JSONEditor > .context ul > li { position: relative; margin: 0; }
@@ -65,7 +68,13 @@
 .JSONEditor > .context[loc=root] > ul > li[role=Duplicate], .JSONEditor > .context[loc=root] > ul > li[role=Remove] { display: none; }
 .JSONEditor > .context[loc=root] > ul > li[role=Type] li[role=String] { display: none; }
 .JSONEditor > .context li[role=Type]:after, .JSONEditor > .context li[role=Insert]:after { content: ''; display: block; z-index: 1; width: 5px; height: 8px; margin-top: -4px; position: absolute; right: 10px; top: 50%; background-position: 0 -30px; }
+.JSONEditor > pre.preview { position: relative; float: right; width: 48%; min-height: 100px; margin: 0; padding: 12px; border: 1px solid #ccc; font-size: 13px; }
+.JSONEditor > pre.preview:before { content: 'Preview'; display: block; position: absolute; padding: 2px 6px 2px 8px; right: 0; top: 0; font-size: 12px; font-weight: 600; font-family: Verdana, sans-serif; color: #666; background: #f5f5f5; border-width: 0 0 1px 1px; border-style: solid; border-color: #ccc; border-bottom-left-radius: 3px; }
+.JSONEditor.preview > div.index { width: 48%; float: left; overflow: auto; }
+.JSONEditor.preview > pre.preview { display: block; }
 
+@media all and (max-width: 640px) { .JSONEditor.preview > div.index { width: auto; float: none; overflow: visible; }
+  .JSONEditor.preview > pre.preview { width: auto; float: none; margin-top: 15px; } }
 /* jQuery Sortable */
 body.dragging { width: 100%; overflow: hidden; }
 

--- a/css/jsonEditor.scss
+++ b/css/jsonEditor.scss
@@ -11,9 +11,18 @@
 
 /* json editor */
 .JSONEditor {
+	position: relative;
+	*, *:before, *:after {
+		box-sizing: border-box;
+		-webkit-box-sizing: border-box;
+		-moz-box-sizing: border-box;
+	}
+	&:after {content: ''; display: block; clear: both;}
+
 	/* index */
 	> div.index {
-		border-width: 1px 0; border-style: solid; border-color: #ccc;
+		position: relative; padding: 8px 12px; margin: 0;
+		border-width: 1px; border-style: solid; border-color: #ccc;
 		font-size: 13px;
 		ul {margin: 0; padding: 0 0 0 22px; list-style: none; clear: both;}
 		> ul {margin: 5px 0; padding-left: 0;}
@@ -158,6 +167,16 @@
 			content: '';
 			left: 0; right: 0; top: -1px; height: 3px; background: #7a7c7d;
 		}
+
+		&:before {
+			content: 'Editor'; display: block; position: absolute;
+			padding: 2px 6px 2px 8px;
+			right: 0; top: 0;
+			font-size: 12px; font-weight: 600; font-family: Verdana, sans-serif; color: #666;
+			background: #f5f5f5;
+			border-width: 0 0 1px 1px; border-style: solid; border-color: #ccc;
+			border-bottom-left-radius: 3px;
+		}
 	}
 
 	/* Context */
@@ -221,8 +240,37 @@
 			@extend %sp-ico;
 		}
 	}
+
+	/* Preview */
+	> pre.preview {
+		position: relative; float: right; width: 48%; min-height: 100px; margin: 0; padding: 12px;
+		border: 1px solid #ccc;
+		font-size: 13px;
+		&:before {
+			content: 'Preview'; display: block; position: absolute;
+			padding: 2px 6px 2px 8px;
+			right: 0; top: 0;
+			font-size: 12px; font-weight: 600; font-family: Verdana, sans-serif; color: #666;
+			background: #f5f5f5;
+			border-width: 0 0 1px 1px; border-style: solid; border-color: #ccc;
+			border-bottom-left-radius: 3px;
+		}
+	}
+
+	&.preview {
+		> div.index {width: 48%; float: left; overflow: auto;}
+		> pre.preview {display: block;}
+	}
 }
 
+@media all and (max-width:640px) {
+	.JSONEditor {
+		&.preview {
+			> div.index {width: auto; float: none; overflow: visible;}
+			> pre.preview {width: auto; float: none; margin-top: 15px;}
+		}
+	}
+}
 
 /* jQuery Sortable */
 body.dragging {width: 100%; overflow: hidden}

--- a/index.html
+++ b/index.html
@@ -18,6 +18,8 @@
 	<div class="JSONEditor"></div>
 	<!-- // JSON editor -->
 
+	<hr />
+
 	<!-- result -->
 	<div id="jsonResult">
 		<nav class="btngroup">

--- a/js/JSONEditor.class.js
+++ b/js/JSONEditor.class.js
@@ -12,17 +12,19 @@ Object.size = function(obj) {
  * JSON Editor Class
  * 
  * author : Redgoose (2014.03)
- * version : 0.2
+ * version : 0.3
  * website : http://redgoose.me
- * @param Array $wrap : json editor 껍데기 엘리먼트
+ * @Param {Array} $wrap : json editor 껍데기 엘리먼트
+ * @Param {Boolean} usePreview : 프리뷰 창을 사용할건지에 대한 값
  * @return void
  */
-var JSONEditor = function($wrap)
+var JSONEditor = function($wrap, usePreview)
 {
 	var self = this;
 
 	self.$wrap = $wrap;
 	self.$index = null;
+	self.$preview = null;
 
 	var util = new Util();
 	var context = new Context(this, this.contextTree);
@@ -211,9 +213,15 @@ var JSONEditor = function($wrap)
 	 */
 	var init = function()
 	{
-		self.$index = $('<div class="index"/>');
+		self.$index = $('<div class="index" />');
 		self.$index.append(createRoot());
 		self.$wrap.prepend(self.$index);
+
+		self.$preview = $('<pre class="preview" />');
+		self.$wrap.append(self.$preview);
+		self.$wrap.addClass('preview');
+
+		updatePreview();
 	}
 
 	/**
@@ -286,10 +294,16 @@ var JSONEditor = function($wrap)
 	var inputCheckEvent = function($item)
 	{
 		var $strong = $item.find('> dl > dt > strong');
+		var $inputs = $item.find('> dl > dt > strong, > dl > dd > span');
+
 		$strong.on('blur', function(){
 			util.removeBR($(this));
 			util.removeSpace($(this));
 			util.stringLimiter($(this), 20);
+		});
+		// preview update
+		$inputs.on('blur', function(){
+			updatePreview();
 		});
 	}
 
@@ -315,7 +329,6 @@ var JSONEditor = function($wrap)
 		});
 	}
 
-
 	/**
 	 * drag event
 	 * 
@@ -338,6 +351,8 @@ var JSONEditor = function($wrap)
 	
 				updateNumber(beforeItem.children());
 				updateNumber(targetContainer.el.children());
+
+				updatePreview();
 	
 				beforeItem = adjustment = null;
 			}
@@ -366,7 +381,7 @@ var JSONEditor = function($wrap)
 	}
 
 	/**
-	 * create root node
+	 * Create root node
 	 * 
 	 * @return {DOM}
 	 */
@@ -385,6 +400,14 @@ var JSONEditor = function($wrap)
 		dragEvent($li);
 
 		return $ul;
+	}
+
+	/**
+	 * Updata preview
+	 */
+	var updatePreview = function()
+	{
+		self.$preview.text(self.exportJSON(5));
 	}
 
 
@@ -431,6 +454,7 @@ var JSONEditor = function($wrap)
 	{
 		$active.attr('type', type);
 		$active.find('> dl > dt > strong').attr('data-ph', type);
+		updatePreview();
 	}
 
 	/**
@@ -447,6 +471,7 @@ var JSONEditor = function($wrap)
 		});
 		updateCount($target.parent().parent());
 		updateNumber($target.parent().children());
+		updatePreview();
 	}
 
 	/**
@@ -459,6 +484,7 @@ var JSONEditor = function($wrap)
 		var $parentItem = $target.parent().parent();
 		$target.remove();
 		updateCount($parentItem);
+		updatePreview();
 	}
 
 	/**
@@ -494,6 +520,7 @@ var JSONEditor = function($wrap)
 			});
 		}
 		items(data, self.$index.find('[loc=root]'));
+		updatePreview();
 	}
 
 	/**


### PR DESCRIPTION
에디터 우측에 프리뷰 창을 넣고 수정하고 포커스에서 떼면 프리뷰 화면에서 json소스가 출력된다.
대부분의 노드 액션(타입변경, 복제, 삭제)을 실행하면 프리뷰가 업데이트가 되지만 노드 추가할때는 프리뷰 업데이트 하지 않는다. 왜냐하면 값이 비어있는 상태이기 때문에 굳이 프리뷰 업데이트를 해야할 필요성을 느끼지 못했다.
